### PR TITLE
add support of "rpcconnect" parameter of bitcoin.conf

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -91,6 +91,7 @@ class RawProxy(object):
                     service_port = bitcoin.params.RPC_PORT
                 conf['rpcport'] = int(conf.get('rpcport', service_port))
                 conf['rpcssl'] = conf.get('rpcssl', '0')
+                conf['rpchost'] = conf.get('rpcconnect', 'localhost')
 
                 if conf['rpcssl'].lower() in ('0', 'false'):
                     conf['rpcssl'] = False
@@ -102,10 +103,10 @@ class RawProxy(object):
                 if 'rpcpassword' not in conf:
                     raise ValueError('The value of rpcpassword not specified in the configuration file: %s' % btc_conf_file)
 
-                service_url = ('%s://%s:%s@localhost:%d' %
+                service_url = ('%s://%s:%s@%s:%d' %
                     ('https' if conf['rpcssl'] else 'http',
                      conf['rpcuser'], conf['rpcpassword'],
-                     conf['rpcport']))
+                     conf['rpchost'], conf['rpcport']))
 
         self.__service_url = service_url
         self.__url = urlparse.urlparse(service_url)


### PR DESCRIPTION
At this point, you can specify a host for rpc.Proxy only as part of service_url. This patch allows the use of standard setting "rpcconnect" in bitcoin config file.